### PR TITLE
add ProgressIndicator to prevent unwanted props being passed

### DIFF
--- a/client/imports/components/counties.js
+++ b/client/imports/components/counties.js
@@ -3,11 +3,11 @@ import {Meteor} from "meteor/meteor";
 import {composeWithTracker} from 'react-komposer';
 
 import Map from "./counties-map-wgt";
-import CircularProgress from 'material-ui/CircularProgress';
+import ProgressIndicator from "./progress-indicator";
 import loadData from "../composers/load-resource-data";
 import loadMapData from "../composers/load-map-data";
 
-let MapWidget = composeWithTracker(loadMapData, CircularProgress)(Map);
+let MapWidget = composeWithTracker(loadMapData, ProgressIndicator)(Map);
 
 class Counties extends React.Component {
 

--- a/client/imports/components/demand.js
+++ b/client/imports/components/demand.js
@@ -3,10 +3,10 @@ import {Meteor} from "meteor/meteor";
 import {composeWithTracker} from 'react-komposer';
 
 import loadAggregate from "../composers/aggregate";
-import CircularProgress from 'material-ui/CircularProgress';
+import ProgressIndicator from "./progress-indicator";
 import Lsoas from "./lsoas";
 
-let LsoasDisplay = composeWithTracker(loadAggregate, CircularProgress)(Lsoas);
+let LsoasDisplay = composeWithTracker(loadAggregate, ProgressIndicator)(Lsoas);
 
 
 class Demand extends React.Component {

--- a/client/imports/components/lsoas.js
+++ b/client/imports/components/lsoas.js
@@ -8,10 +8,10 @@ import Pyramid from "./pyramid-wgt";
 import Map from "./map-wgt";
 import loadData from "../composers/load-resource-data";
 import loadMapData from "../composers/load-map-data";
-import CircularProgress from 'material-ui/CircularProgress';
+import ProgressIndicator from "./progress-indicator";
 
-let PyramidWidget = composeWithTracker(loadData, CircularProgress)(Pyramid);
-let MapWidget = composeAll(composeWithTracker(loadMapData, CircularProgress), composeWithTracker(loadData, CircularProgress))(Map);
+let PyramidWidget = composeWithTracker(loadData, ProgressIndicator)(Pyramid);
+let MapWidget = composeAll(composeWithTracker(loadMapData, ProgressIndicator), composeWithTracker(loadData, ProgressIndicator))(Map);
 
 class Lsoa extends React.Component {
 
@@ -40,24 +40,26 @@ class Lsoa extends React.Component {
 
   popDensity(feature) {
 
-    let population = _.find(this.data, function (poplet) {
-      if (poplet.area_id == feature.properties.LSOA11CD) return true;
-      else return false;
-    });
+    // let population = _.find(this.data, function (poplet) {
+    //   if (poplet.area_id == feature.properties.LSOA11CD) return true;
+    //   else return false;
+    // });
     
-    let d = population.persons/feature.properties.area;
-    let heat =  d > 0.014   ? "#800026" : 
-                d > 0.01    ? "#bd0026" :    
-                d > 0.005   ? "#e31a1c" :
-                d > 0.001   ? "#fc4e2a" :
-                d > 0.0005  ? "#fd8d3c" :
-                d > 0.0001  ? "#feb24c" :
-                d > 0.00008 ? "#fed976" :
-                d > 0.00005 ? "#4292c6":
-                d > 0.00003 ? "#2171b5" :
-                d > 0.00001 ? "#08519c" :
-                            "#08306b";
-    return {fillColor: heat, color: '#FF0000', weight: 1, fillOpacity: 0.5};
+    // let d = population.persons/feature.properties.area;
+    // let heat =  d > 0.014   ? "#800026" : 
+    //             d > 0.01    ? "#bd0026" :    
+    //             d > 0.005   ? "#e31a1c" :
+    //             d > 0.001   ? "#fc4e2a" :
+    //             d > 0.0005  ? "#fd8d3c" :
+    //             d > 0.0001  ? "#feb24c" :
+    //             d > 0.00008 ? "#fed976" :
+    //             d > 0.00005 ? "#4292c6":
+    //             d > 0.00003 ? "#2171b5" :
+    //             d > 0.00001 ? "#08519c" :
+    //                         "#08306b";
+    // return {fillColor: heat, color: '#FF0000', weight: 1, fillOpacity: 0.5};
+
+    return {fillColor: "#e31a1c", color: '#FF0000', weight: 1, fillOpacity: 0.5};
   }
 
   render() {

--- a/client/imports/components/progress-indicator.js
+++ b/client/imports/components/progress-indicator.js
@@ -1,0 +1,8 @@
+import React from "react";
+import CircularProgress from 'material-ui/CircularProgress';
+
+const ProgressIndicator = () => {
+  return <CircularProgress />;
+};
+
+export default ProgressIndicator;

--- a/client/imports/composers/load-map-data.js
+++ b/client/imports/composers/load-map-data.js
@@ -6,7 +6,9 @@ import connectionManager from "../connection-manager";
 function loadMapData({mapId, mapFilter, options}, onData) {
  // console.log("loadResourceData: ", mapId, mapFilter, options);
 
-
+  if (mapFilter && mapFilter._d) {
+    debugger;
+  }
   
   // Subscribe to the datasetData publication using the given filter and options.
   // The subscription will automatically re-run if any of the parameters change (i.e. resourceId, filter or options).
@@ -18,9 +20,9 @@ function loadMapData({mapId, mapFilter, options}, onData) {
       // The subscription is ready
       mapFilter = mapFilter || {};
       // Add filter for dataset data (all datasetData subscriptions are stored in the same collection).
-      let clientFilter = _.extend(mapFilter,{_d: mapId})
+      let clientFilter = _.extend(mapFilter,{_d: mapId});
       // Fetch the data from the local cache.
-      const datasetData = connectionManager.datasetDataCollection.find(mapFilter,options).fetch();
+      const datasetData = connectionManager.datasetDataCollection.find(clientFilter,options).fetch();
       // Pass the data on to the component via the data property.      
       onData(null, {geoData: datasetData});
     }

--- a/client/imports/composers/load-resource-data.js
+++ b/client/imports/composers/load-resource-data.js
@@ -5,10 +5,11 @@ import connectionManager from "../connection-manager";
 // options - options to tweak the returned data, e.g. { sort: { timestamp: -1 }, limit: 10, fields: {temperature: 1}} will sort by timestamp descending, limit the result to 10 items, and only return the temperature field in each document.
 function loadResourceData({resourceId, filter, options}, onData) {
   //console.log("loadResourceData: ", resourceId, filter, options);
-  
-  
-  delete filter._d;
-  
+    
+  if (filter && filter._d) {
+    debugger;
+  }
+
   // Subscribe to the datasetData publication using the given filter and options.
   // The subscription will automatically re-run if any of the parameters change (i.e. resourceId, filter or options).
   const sub = connectionManager.subscribe("datasetData",resourceId, filter, options, {
@@ -20,7 +21,7 @@ function loadResourceData({resourceId, filter, options}, onData) {
       filter = filter || {};
       
       // Add filter for dataset data (all datasetData subscriptions are stored in the same collection).
-      let clientFilter = _.extend(filter,{_d: resourceId})
+      let clientFilter = _.extend(filter,{_d: resourceId});
       // Fetch the data from the local cache.
       const datasetData = connectionManager.datasetDataCollection.find(clientFilter,options).fetch();
       // Pass the data on to the component via the data property.    


### PR DESCRIPTION
add ProgressIndicator to prevent unwanted props being passed to CircularProgress

fix clientFilter unused issue

there's a bug in popDensity 